### PR TITLE
Add 'Back' button in Questions screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,11 @@ function App() {
       {showWelcome ? (
         <WelcomeScreen setShowModal={setShowModal} />
       ) : (
-        <Questions url={url} />
+        <Questions
+        url={url}
+        setShowModal={setShowModal}
+        setShowWelcome={setShowWelcome}
+        />
       )}
 
       {showModal && (

--- a/src/components/Questions.jsx
+++ b/src/components/Questions.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import Question from "./Question"
 
-function Questions({ url }) {
+function Questions({ url, setShowModal, setShowWelcome }) {
   const [ansRevealed, setAnsRevealed] = useState(false)
   const [questions, setQuestions] = useState([])
   const [points, setPoints] = useState(0)
@@ -59,6 +59,11 @@ function Questions({ url }) {
     })
   }
 
+  function goBack() {
+    setShowModal(true);
+    setShowWelcome(true);
+  }
+
   return (
     <div className="z-10 h-full max-w-6xl flex flex-col justify-center items-start gap-3 p-8 sm:px-16 lg:gap-8 lg:py-16">
       {questions?.length ? (
@@ -94,6 +99,12 @@ function Questions({ url }) {
                 Check Answers
               </button>
             )}
+            <button
+                className="self-center text-white bg-btn-blue font-inter px-6 py-2 rounded-md shadow-xl cursor-pointer transition-all hover:opacity-80 active:scale-90 focus:opacity-80 md:text-xl md:px-12 md:py-4 md:rounded-lg"
+                onClick={goBack}
+              >
+                Back
+              </button>
           </>
         )}
       </div>

--- a/src/components/Questions.jsx
+++ b/src/components/Questions.jsx
@@ -67,7 +67,15 @@ function Questions({ url, setShowModal, setShowWelcome }) {
   return (
     <div className="z-10 h-full max-w-6xl flex flex-col justify-center items-start gap-3 p-8 sm:px-16 lg:gap-8 lg:py-16">
       {questions?.length ? (
-        renderQuestions()
+        <>
+          <button
+            className="self-start text-white bg-btn-blue font-inter px-6 py-2 rounded-md shadow-xl cursor-pointer transition-all hover:opacity-80 active:scale-90 focus:opacity-80 md:text-xl md:px-12 md:py-4 md:rounded-lg"
+            onClick={goBack}
+          >
+          Back
+          </button>
+          {renderQuestions()}
+        </>
       ) : (
         <p className="text-md font-karla text-text-blue md:text-xl lg:text-2xl self-center">
           Loading Quiz...
@@ -99,12 +107,6 @@ function Questions({ url, setShowModal, setShowWelcome }) {
                 Check Answers
               </button>
             )}
-            <button
-                className="self-center text-white bg-btn-blue font-inter px-6 py-2 rounded-md shadow-xl cursor-pointer transition-all hover:opacity-80 active:scale-90 focus:opacity-80 md:text-xl md:px-12 md:py-4 md:rounded-lg"
-                onClick={goBack}
-              >
-                Back
-              </button>
           </>
         )}
       </div>

--- a/src/components/Questions.jsx
+++ b/src/components/Questions.jsx
@@ -69,7 +69,7 @@ function Questions({ url, setShowModal, setShowWelcome }) {
       {questions?.length ? (
         <>
           <button
-            className="self-start text-white bg-btn-blue font-inter px-6 py-2 rounded-md shadow-xl cursor-pointer transition-all hover:opacity-80 active:scale-90 focus:opacity-80 md:text-xl md:px-12 md:py-4 md:rounded-lg"
+            className="text-sm self-start text-white bg-btn-blue font-inter py-1 px-2 md:text-lg lg:text-lg lg:px-8 rounded-md shadow-xl cursor-pointer transition-all hover:opacity-80 active:scale-90 focus:opacity-80 md:rounded-lg"
             onClick={goBack}
           >
           Back


### PR DESCRIPTION
### 🛠️ Fixes #15

<!-- Example: Fixes #31 -->

### Related Issue/Addition to code
- "Back" button in Questions screen for navigating back to topics section

### 👨‍💻 What's being changed:

- Added "Back" button on the Questions screen.
- On clicking the button, topics modal will be displayed where users can pick their favorite.

### Type of change

<!-- Please delete options that are not relevant. -->

<!-- Follow the below conventions to check the box -->
<!--
To mark a box just add 'x' between the [] with any spaces.

[x] This is a marked box. ✅
[ x ] This is NOT marked box. ❌
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### ✔️ Check List (Check all the applicable boxes) 

<!-- Mark all the applicable boxes -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

### 📷 Screenshots

Original | Updated
:----------------------:|:-----------:
 <img width="1378" alt="Screenshot 2022-08-13 at 10 49 37 PM" src="https://user-images.githubusercontent.com/88023922/184505292-8435716c-2cbf-4a77-8c4c-eb31e09faa0f.png">  | <img width="1290" alt="Screenshot 2022-08-13 at 11 23 09 PM" src="https://user-images.githubusercontent.com/88023922/184505376-95bb564a-3346-4a15-b495-98169765c6a0.png">

Original | Updated
:----------------------:|:-----------:
<img width="1333" alt="Screenshot 2022-08-13 at 11 27 16 PM" src="https://user-images.githubusercontent.com/88023922/184505428-7aeec188-c69e-4dbd-9c31-d8b90ac02245.png">  | <img width="1227" alt="Screenshot 2022-08-13 at 11 27 36 PM" src="https://user-images.githubusercontent.com/88023922/184505438-1126032a-9d50-4d62-8efc-79637c811fa4.png">


